### PR TITLE
Fix devtools to work on Windows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,10 +8,11 @@ AllCops:
     - "**/node_modules/**/*"
     - "**/target/**/*"
     - "**/vendor/**/*"
+Layout/EndOfLine:
+  EnforcedStyle: lf
 Layout/LineLength:
   Enabled: true
   Exclude:
-    - "scripts/gen_case_lookups.rb"
     - "**/Rakefile"
 Metrics:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task format: %i[format:text]
 namespace :format do
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 end
 
@@ -34,7 +34,7 @@ task fmt: %i[fmt:text]
 namespace :fmt do
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 end
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "build": "webpack --mode production",
-    "fmt": "npx prettier --write '**/*'",
+    "fmt": "npx prettier --write \"**/*\"",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint --fix ."
   }


### PR DESCRIPTION
- Force unix-style line endings on Windows with RuboCop.
- Fix prettier glob quoting to work  on Windows in `package.json` run script and `Rakefile`.