### PR TITLE
Update Audit GitHub Actions workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -12,6 +12,7 @@ name: Audit
 jobs:
   js:
     name: Audit JS Dependencies
+    if: true
     runs-on: ubuntu-latest
 
     steps:
@@ -23,3 +24,44 @@ jobs:
 
       - name: npm audit
         run: npm audit
+
+  ruby:
+    name: Audit Ruby Dependencies
+    if: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: bundler-audit
+        run: bundle exec bundle-audit check --update
+
+  rust:
+    name: Audit Rust Dependencies
+    if: false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup cargo-deny
+        run: |
+          release_base="https://github.com/EmbarkStudios/cargo-deny/releases/download"
+          version="0.9.1"
+          cargo_deny_tarball="$release_base/$version/cargo-deny-$version-x86_64-unknown-linux-musl.tar.gz"
+          echo "Downloading cargo-deny $version from $cargo_deny_tarball."
+          curl -sL "$cargo_deny_tarball" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+
+      - name: cargo-deny version
+        run: cargo-deny --version
+
+      - name: Run cargo-deny
+        run: cargo-deny check --show-stats

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ available tasks by running:
 ```console
 $ bundle exec rake --tasks
 rake build                        # Build Webpack bundle
+rake bundle:audit                 # Checks the Gemfile.lock for insecure dependencies
 rake fmt                          # Format sources
 rake fmt:text                     # Format text, YAML, and Markdown sources with prettier
 rake format                       # Format sources

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'bundler-audit', '~> 0.8', require: false
 gem 'rake', '>= 12.3.3', require: false
 gem 'rubocop', '~> 1.18', require: false
 gem 'rubocop-rake', '~> 0.6', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    bundler-audit (0.8.0)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -23,15 +26,17 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
+    thor (1.1.0)
     unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler-audit (~> 0.8)
   rake (>= 12.3.3)
   rubocop (~> 1.18)
   rubocop-rake (~> 0.6)
 
 BUNDLED WITH
-   2.0.2
+   2.2.22

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require 'open-uri'
 require 'shellwords'
+require 'bundler/audit/task'
 require 'rubocop/rake_task'
 
 task default: %i[format lint]
@@ -42,6 +43,8 @@ desc 'Build Webpack bundle'
 task :build do
   sh 'npm run build'
 end
+
+Bundler::Audit::Task.new
 
 namespace :release do
   link_check_files = FileList.new('**/*.md') do |f|


### PR DESCRIPTION
Managed by Terraform.

The cargo-deny version is 0.9.1.

Pushed commit c5e79d14df1c5c7d2d0839c6e746e00d7e26709e.
