### PR TITLE
Update bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,4 +39,4 @@ DEPENDENCIES
   rubocop-rake (~> 0.6)
 
 BUNDLED WITH
-   2.2.22
+   2.3.7


### PR DESCRIPTION
Address this warning:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

This regression was introduced in:

- #102 