### PR TITLE
npm rm @minify-html/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       },
       "devDependencies": {
         "@eslint/js": "9.21.0",
-        "@minify-html/node": "^0.15.0",
         "eslint": "9.21.0",
         "prettier": "3.5.2",
         "rimraf": "^6.0.1",
@@ -663,64 +662,6 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
-    },
-    "node_modules/@minify-html/node": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@minify-html/node/-/node-0.15.0.tgz",
-      "integrity": "sha512-ANzt6ZBiqtwrepVXRfa0Qn/woCkINFBjQEKiXyBmg7+51mIFQHVAUbAm6UHRrT0L3xoPG0BX0/XI3NqtjK8Vyg==",
-      "dev": true,
-      "bin": {
-        "minify-html": "cli.js"
-      },
-      "engines": {
-        "node": ">= 8.6.0"
-      },
-      "optionalDependencies": {
-        "@minify-html/node-darwin-arm64": "0.15.0",
-        "@minify-html/node-darwin-x64": "0.15.0",
-        "@minify-html/node-linux-arm64": "0.15.0",
-        "@minify-html/node-linux-x64": "0.15.0",
-        "@minify-html/node-win32-x64": "0.15.0"
-      }
-    },
-    "node_modules/@minify-html/node-darwin-x64": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@minify-html/node-darwin-x64/-/node-darwin-x64-0.15.0.tgz",
-      "integrity": "sha512-D9M9UDku/8I5VEMS0gTLFFQK1DFXK8io+QZvR5cbya4u8NmdDQix/t3EyCR4Wgv/Gfk86gwIS+zfMSvuKcpb5A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@minify-html/node-linux-x64": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@minify-html/node-linux-x64/-/node-linux-x64-0.15.0.tgz",
-      "integrity": "sha512-cO893EV6O9ZHUFX+2Yge546OCo/eCiatjzJDmUmrPP56fQ7pzTRquHs4ko3t8Rg6tMKG7RT49mBuF09JWPnrgg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@minify-html/node-win32-x64": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@minify-html/node-win32-x64/-/node-win32-x64-0.15.0.tgz",
-      "integrity": "sha512-n92IFdtntchlUtyrq13pRI8TT3sOddbzuo4EPTSeocuTJMXaR77v0JYDu0fIjxXNawgGq6nBEeicxAcH4CbvUQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@eslint/js": "9.21.0",
-    "@minify-html/node": "^0.15.0",
     "eslint": "9.21.0",
     "prettier": "3.5.2",
     "rimraf": "^6.0.1",


### PR DESCRIPTION
This dep is no longer in use as of #170. Remove it from the dependency list and lockfile.